### PR TITLE
index.html: remove 'truenas' from roadmap

### DIFF
--- a/index.html
+++ b/index.html
@@ -364,7 +364,7 @@
                 </div>
                 <div class="timeline-item">
                     <h3><i class="fas fa-code-branch"></i> 13.5 Migration</h3>
-                    <p>While we work on a stable release of 13.3, we will update to TrueNAS 13.5.</p>
+                    <p>While we work on a stable release of 13.3, we will update to 13.5.</p>
                 </div>
                 <div class="timeline-item">
                     <h3><i class="fas fa-project-diagram"></i> 14.0 Planning</h3>


### PR DESCRIPTION
1. Removed the word 'truenas' from the roadmap for 13.5 release.