### PR TITLE
Front page: there is no TrueNAS 13.5

### DIFF
--- a/index.html
+++ b/index.html
@@ -364,7 +364,7 @@
                 </div>
                 <div class="timeline-item">
                     <h3><i class="fas fa-code-branch"></i> 13.5 Migration</h3>
-                    <p>While we work on a stable release of 13.3, we will update to TrueNAS 13.5.</p>
+                    <p>While we work on a stable release of 13.3, we will update to 13.5.</p>
                 </div>
                 <div class="timeline-item">
                     <h3><i class="fas fa-project-diagram"></i> 14.0 Planning</h3>


### PR DESCRIPTION
At https://www.truenas.com/docs/softwarereleases/ for TrueNAS Core™:

* the Current tab shows 13.3-U1.2, which was the final update to 13.3
* I should not expect the Next tab to show 13.5.